### PR TITLE
Fix bug where controller is not finishing processing events in the queue | Results in reconciler only running once

### DIFF
--- a/.changes/unreleased/Bugfix-20240114-015652.yaml
+++ b/.changes/unreleased/Bugfix-20240114-015652.yaml
@@ -1,4 +1,0 @@
-kind: Bugfix
-body: Fix bug where WaitGroup.Done() is called too early resulting in k8s events not
-  being processed
-time: 2024-01-14T01:56:52.741895-05:00

--- a/.changes/unreleased/Bugfix-20240115-131933.yaml
+++ b/.changes/unreleased/Bugfix-20240115-131933.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where controller.Start() would only run the mainloop once
+time: 2024-01-15T13:19:33.513054-05:00

--- a/.changes/unreleased/Bugfix-20240115-131933.yaml
+++ b/.changes/unreleased/Bugfix-20240115-131933.yaml
@@ -1,3 +1,0 @@
-kind: Bugfix
-body: Fix bug where controller.Start() would only run the mainloop once
-time: 2024-01-15T13:19:33.513054-05:00

--- a/.changes/unreleased/Bugfix-20240115-135040.yaml
+++ b/.changes/unreleased/Bugfix-20240115-135040.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix concurrency bug that caused the informer queue to never become exhausted,
+  leading to new events from informers not being processed.
+time: 2024-01-15T13:50:40.077433-05:00

--- a/controller.go
+++ b/controller.go
@@ -78,9 +78,10 @@ func (c *K8SController) mainloop(item interface{}) {
 	}
 }
 
-// Start - starts the informer faktory and sync's the data.
-// The wait group passed in is used to track when the informer has gone
-// through 1 full loop and syncronized all the k8s data 1 time
+// Start - starts the informer factory, increments WaitGroup counter, and starts a goroutine.
+// The goroutine will make calls to mainloop until the queue is exhausted. Items in the queue
+// are marked as Done() by the mainloop. Once the queue is exhausted the goroutine exits
+// and Start decrements the WaitGroup counter before exiting.
 func (c *K8SController) Start(wg *sync.WaitGroup) {
 	defer runtime.HandleCrash()
 	defer wg.Done()

--- a/controller.go
+++ b/controller.go
@@ -78,13 +78,11 @@ func (c *K8SController) mainloop(item interface{}) {
 	}
 }
 
-// Start - starts the informer factory, increments WaitGroup counter, and starts a goroutine.
-// The goroutine will make calls to mainloop until the queue is exhausted. Items in the queue
-// are marked as Done() by the mainloop. Once the queue is exhausted the goroutine exits
-// and Start decrements the WaitGroup counter before exiting.
+// Start - starts the informer faktory and sync's the data.
+// The wait group passed in is used to track when the informer has gone
+// through 1 full loop and syncronized all the k8s data 1 time
 func (c *K8SController) Start(wg *sync.WaitGroup) {
 	defer runtime.HandleCrash()
-	defer wg.Done()
 	if wg != nil {
 		wg.Add(1)
 	}
@@ -101,6 +99,9 @@ func (c *K8SController) Start(wg *sync.WaitGroup) {
 		for {
 			item, quit := c.queue.Get()
 			if quit {
+				if wg != nil {
+					wg.Done()
+				}
 				return
 			}
 			c.mainloop(item)


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/kubectl-opslevel/pull/236

Explanation: read changelog and comments in PR. 

## Changelog

- [x] `mainloop()` - always defer call to `c.queue.Done()` even if the item was not processed by an event handler. Otherwise, events from the informer are never removed.
- [x] `Start()` - defer call to `wg.Done()` instead of doing that in the goroutine, which is unsafe. Also, stop manually calling shutdown on the queue, the informer lets us know if the queue is shutting down when we call `c.queue.Get()`.
- [x] Make a `changie` entry

## Tophatting

[See my latest kubectl-opslevel PR](https://github.com/OpsLevel/kubectl-opslevel/pull/236)
