### PR TITLE
drop docker work from release, add lint,fmt check to tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,15 +71,6 @@ jobs:
           fi
           git tag -f ${{ steps.version.outputs.RELEASE_VERSION }} -m "Cut Release '${{ steps.version.outputs.RELEASE_VERSION }}'"
           git push -f origin refs/tags/${{ steps.version.outputs.RELEASE_VERSION }}
-      # This needs to happen after the above, so we don't commit the ./libjq folder
-      - name: Setup LibJQ
-        run: |-
-          docker run --name "libjq" -d flant/jq:b6be13d5-glibc
-          docker cp libjq:/libjq ./libjq 
-          docker rm libjq
-          echo CGO_ENABLED=1 >> $GITHUB_ENV
-          echo CGO_CFLAGS="-I$(pwd)/libjq/include" >> $GITHUB_ENV
-          echo CGO_LDFLAGS="-L$(pwd)/libjq/lib" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -89,7 +80,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Report Release To OpsLevel
-        uses: opslevel/report-deploy-github-action@v0.6.0
+        uses: opslevel/report-deploy-github-action@v0.7.0
         with:
           integration_url: ${{ secrets.DEPLOY_INTEGRATION_URL }}
           service: "opslevel_k8s_controller"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths:
+      - '.github/workflows/tests.yml'
+      - '**.go'
+      - 'go.mod'
 
 jobs:
   test:
@@ -20,6 +24,13 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Setup LibJQ
         run: |-
           docker run --name "libjq" -d flant/jq:b6be13d5-glibc
@@ -28,6 +39,11 @@ jobs:
           echo CGO_ENABLED=1 >> $GITHUB_ENV
           echo CGO_CFLAGS="-I$(pwd)/libjq/include" >> $GITHUB_ENV
           echo CGO_LDFLAGS="-L$(pwd)/libjq/lib" >> $GITHUB_ENV
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run quality checks and test code
         run: task ci
       - name: Upload Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,14 +23,16 @@ jobs:
       - name: Setup LibJQ
         run: |-
           docker run --name "libjq" -d flant/jq:b6be13d5-glibc
-          docker cp libjq:/libjq ./libjq 
+          docker cp libjq:/libjq ./libjq
           docker rm libjq
           echo CGO_ENABLED=1 >> $GITHUB_ENV
           echo CGO_CFLAGS="-I$(pwd)/libjq/include" >> $GITHUB_ENV
           echo CGO_LDFLAGS="-L$(pwd)/libjq/lib" >> $GITHUB_ENV
-      - name: Run Tests
-        run: |-
-          go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+      - name: Run quality checks and test code
+        run: task ci
       - name: Upload Coverage
-        run: |-
-          bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          fail_ci_if_error: false
+          verbose: true


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Drop unused docker work from release workflow. `goreleaser` skips building.
Add lint and formatting checks to test workflow

- [X] List your changes here
- [ ] Make a `changie` entry, N/A CI only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
