### PR TITLE
add namespace filter back

### DIFF
--- a/.changes/unreleased/Feature-20240422-144716.yaml
+++ b/.changes/unreleased/Feature-20240422-144716.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add back ability to filter resouces by namespace instead of just excludes
+time: 2024-04-22T14:47:16.908901-05:00

--- a/controller.go
+++ b/controller.go
@@ -60,11 +60,11 @@ func (c *K8SController) mainloop(item interface{}) {
 		return
 	}
 	if !c.filter.MatchesNamespace(obj) {
-		log.Warn().Msgf("object with key '%s' skipped because it doesn't match targeted namespaces", event.Key)
+		log.Debug().Msgf("object with key '%s' skipped because it doesn't match targeted namespaces", event.Key)
 		return
 	}
 	if c.filter.MatchesFilter(obj) {
-		log.Warn().Msgf("object with key '%s' skipped because it matches filter", event.Key)
+		log.Debug().Msgf("object with key '%s' skipped because it matches filter", event.Key)
 		return
 	}
 	switch event.Type {

--- a/controller.go
+++ b/controller.go
@@ -59,8 +59,12 @@ func (c *K8SController) mainloop(item interface{}) {
 		log.Debug().Msgf("object with key '%s' skipped because it was not found", event.Key)
 		return
 	}
-	if c.filter.Matches(obj) {
-		log.Debug().Msgf("object with key '%s' skipped because it matches filter", event.Key)
+	if !c.filter.MatchesNamespace(obj) {
+		log.Warn().Msgf("object with key '%s' skipped because it doesn't match targeted namespaces", event.Key)
+		return
+	}
+	if c.filter.MatchesFilter(obj) {
+		log.Warn().Msgf("object with key '%s' skipped because it matches filter", event.Key)
 		return
 	}
 	switch event.Type {

--- a/filter.go
+++ b/filter.go
@@ -2,9 +2,10 @@ package opslevel_k8s_controller
 
 import (
 	"encoding/json"
+	"strconv"
+
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2024"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 type K8SResource struct {

--- a/filter.go
+++ b/filter.go
@@ -2,26 +2,52 @@ package opslevel_k8s_controller
 
 import (
 	"encoding/json"
-	"strconv"
-
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2024"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
 )
 
+type K8SResource struct {
+	Metadata v1.ObjectMeta `json:"metadata"`
+}
+
 type K8SFilter struct {
-	parser *opslevel_jq_parser.JQArrayParser
+	namespaces []string
+	parser     *opslevel_jq_parser.JQArrayParser
 }
 
 func NewK8SFilter(selector K8SSelector) *K8SFilter {
 	return &K8SFilter{
-		parser: opslevel_jq_parser.NewJQArrayParser(selector.Excludes),
+		namespaces: selector.Namespaces,
+		parser:     opslevel_jq_parser.NewJQArrayParser(selector.Excludes),
 	}
 }
 
-func (f *K8SFilter) Matches(data any) bool {
+func (f *K8SFilter) MatchesNamespace(data any) bool {
 	j, err := json.Marshal(data)
 	if err != nil {
 		return false
 	}
+	if len(f.namespaces) <= 0 {
+		return true
+	}
+	var res K8SResource
+	if err = json.Unmarshal(j, &res); err == nil {
+		for _, namespace := range f.namespaces {
+			if res.Metadata.Namespace == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (f *K8SFilter) MatchesFilter(data any) bool {
+	j, err := json.Marshal(data)
+	if err != nil {
+		return false
+	}
+
 	// TODO: handle error
 	results, _ := f.parser.Run(string(j))
 	return anyIsTrue(results)

--- a/filter_test.go
+++ b/filter_test.go
@@ -50,17 +50,31 @@ func TestFilter(t *testing.T) {
 		},
 	}
 	filter4 := opslevel_k8s_controller.NewK8SFilter(selector4)
+	selector5 := opslevel_k8s_controller.K8SSelector{
+		Namespaces: []string{
+			`default`,
+		},
+	}
+	filter5 := opslevel_k8s_controller.NewK8SFilter(selector5)
+	selector6 := opslevel_k8s_controller.K8SSelector{
+		Namespaces: []string{
+			`kube-system`,
+		},
+	}
+	filter6 := opslevel_k8s_controller.NewK8SFilter(selector6)
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
 		panic(err)
 	}
 
 	// Act
-	matches1 := filter1.Matches(parsed)
-	matches2 := filter2.Matches(parsed)
-	matches3 := filter3.Matches(parsed)
-	matches4 := filter4.Matches(parsed)
-	matches5 := filter4.Matches(make(chan int))
+	matches1 := filter1.MatchesFilter(parsed)
+	matches2 := filter2.MatchesFilter(parsed)
+	matches3 := filter3.MatchesFilter(parsed)
+	matches4 := filter4.MatchesFilter(parsed)
+	matches5 := filter4.MatchesFilter(make(chan int))
+	matches6 := filter5.MatchesNamespace(parsed)
+	matches7 := filter6.MatchesNamespace(parsed)
 
 	// Assert
 	autopilot.Equals(t, true, matches1)
@@ -68,4 +82,6 @@ func TestFilter(t *testing.T) {
 	autopilot.Equals(t, true, matches3)
 	autopilot.Equals(t, false, matches4)
 	autopilot.Equals(t, false, matches5)
+	autopilot.Equals(t, true, matches6)
+	autopilot.Equals(t, false, matches7)
 }


### PR DESCRIPTION
## Issues

Reported by a customer that this functionality didn't work in the 2024 version.  This adds back this functionality of the k8s selector

## Changelog

- [x] Make a `changie` entry

## Tophatting

When run with a namespaces list in the selector configuration like this

```yaml
service:
    import:
        - selector:
            apiVersion: apps/v1
            kind: Deployment
            namespaces:
              - staging3
```

you get the output

```
2:42PM DBG object with key 'staging/web-primary' skipped because it doesn't match targeted namespaces
2:42PM DBG object with key '1password/scim-bridge' skipped because it doesn't match targeted namespaces
2:42PM DBG object with key 'ingress/external' skipped because it doesn't match targeted namespaces
2:42PM DBG object with key 'opslevel/minio-create-bucket' skipped because it doesn't match targeted namespaces
2:42PM DBG object with key 'opslevel/redis' skipped because it doesn't match targeted namespaces
2:42PM DBG object with key 'self-hosted/redis' skipped because it doesn't match targeted namespaces
```
